### PR TITLE
feat: migrate to Istio HTTPRoute, add oauth2-proxy RBAC and SSO

### DIFF
--- a/charts/mlflow/templates/httproute.yaml
+++ b/charts/mlflow/templates/httproute.yaml
@@ -13,6 +13,6 @@ spec:
     - {{ .Values.httproute.host | quote }}
   rules:
     - backendRefs:
-        - name: mlflow
-          port: 80
+        - name: {{ .Values.httproute.backend_service | default "mlflow" }}
+          port: {{ .Values.httproute.backend_port | default 80 }}
 {{- end }}

--- a/charts/mlflow/templates/httproute.yaml
+++ b/charts/mlflow/templates/httproute.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.mlflow.httproute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mlflow
+spec:
+  parentRefs:
+    - name: {{ .Values.mlflow.httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ .Values.mlflow.httproute.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
+  hostnames:
+    - {{ .Values.mlflow.httproute.host | quote }}
+  rules:
+    - backendRefs:
+        - name: mlflow
+          port: 80
+{{- end }}

--- a/charts/mlflow/templates/httproute.yaml
+++ b/charts/mlflow/templates/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mlflow.httproute.enabled }}
+{{- if .Values.httproute.enabled }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -6,11 +6,11 @@ metadata:
   name: mlflow
 spec:
   parentRefs:
-    - name: {{ .Values.mlflow.httproute.gateway_name | default "istio-gateway" }}
-      namespace: {{ .Values.mlflow.httproute.gateway_namespace | default "istio-ingress" }}
+    - name: {{ .Values.httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ .Values.httproute.gateway_namespace | default "istio-ingress" }}
       sectionName: https
   hostnames:
-    - {{ .Values.mlflow.httproute.host | quote }}
+    - {{ .Values.httproute.host | quote }}
   rules:
     - backendRefs:
         - name: mlflow

--- a/charts/mlflow/templates/oauth2-proxy.yaml
+++ b/charts/mlflow/templates/oauth2-proxy.yaml
@@ -44,6 +44,7 @@ spec:
             - --skip-provider-button=true
             - --pass-access-token=true
             - --pass-user-headers=true
+            - --skip-jwt-bearer-tokens=true
             {{- range .Values.oauth2proxy.extraArgs }}
             - {{ . | quote }}
             {{- end }}

--- a/charts/mlflow/templates/oauth2-proxy.yaml
+++ b/charts/mlflow/templates/oauth2-proxy.yaml
@@ -38,7 +38,7 @@ spec:
             - --oidc-issuer-url={{ .Values.oauth2proxy.oidc.issuerUrl }}
             - --client-id={{ .Values.oauth2proxy.oidc.clientId }}
             - --email-domain=*
-            - --scope=openid email profile
+            - --scope=openid email profile groups
             - --cookie-secure=true
             - --cookie-samesite=lax
             - --skip-provider-button=true

--- a/charts/mlflow/templates/oauth2-proxy.yaml
+++ b/charts/mlflow/templates/oauth2-proxy.yaml
@@ -1,0 +1,97 @@
+{{- if .Values.oauth2proxy.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mlflow-oauth2-proxy
+  labels:
+    app.kubernetes.io/name: mlflow-oauth2-proxy
+type: Opaque
+stringData:
+  OAUTH2_PROXY_CLIENT_SECRET: {{ .Values.oauth2proxy.oidc.clientSecret | quote }}
+  OAUTH2_PROXY_COOKIE_SECRET: {{ .Values.oauth2proxy.cookieSecret | quote }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mlflow-oauth2-proxy
+  labels:
+    app.kubernetes.io/name: mlflow-oauth2-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mlflow-oauth2-proxy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mlflow-oauth2-proxy
+    spec:
+      containers:
+        - name: oauth2-proxy
+          image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
+          args:
+            - --provider=keycloak-oidc
+            - --http-address=0.0.0.0:4180
+            - --upstream={{ .Values.oauth2proxy.upstreamUrl }}
+            - --redirect-url={{ .Values.oauth2proxy.redirectUrl }}
+            - --oidc-issuer-url={{ .Values.oauth2proxy.oidc.issuerUrl }}
+            - --client-id={{ .Values.oauth2proxy.oidc.clientId }}
+            - --email-domain=*
+            - --scope=openid email profile
+            - --cookie-secure=true
+            - --cookie-samesite=lax
+            - --skip-provider-button=true
+            - --pass-access-token=true
+            - --pass-user-headers=true
+            {{- range .Values.oauth2proxy.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          env:
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-oauth2-proxy
+                  key: OAUTH2_PROXY_CLIENT_SECRET
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: mlflow-oauth2-proxy
+                  key: OAUTH2_PROXY_COOKIE_SECRET
+          ports:
+            - name: http
+              containerPort: 4180
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: 4180
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 4180
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mlflow-oauth2-proxy
+  labels:
+    app.kubernetes.io/name: mlflow-oauth2-proxy
+spec:
+  selector:
+    app.kubernetes.io/name: mlflow-oauth2-proxy
+  ports:
+    - name: http
+      port: 4180
+      targetPort: 4180
+{{- end }}

--- a/locals.tf
+++ b/locals.tf
@@ -72,7 +72,10 @@ locals {
         clientId     = var.oidc.client_id
         clientSecret = var.oidc.client_secret
       }
-      extraArgs = var.oidc.oauth2_proxy_extra_args
+      extraArgs = concat(
+        var.oidc.oauth2_proxy_extra_args,
+        [for g in var.allowed_groups : "--allowed-group=${g}"]
+      )
     }
   }] : []
 }

--- a/locals.tf
+++ b/locals.tf
@@ -44,31 +44,13 @@ locals {
       }
       ingress = {
         # -- Specifies if you want to create an ingress access
-        enabled : true
-        # -- New style ingress class name. Only possible if you use K8s 1.18.0 or later version
-        className : "traefik"
-        # -- Additional ingress annotations
-        annotations = {
-          "cert-manager.io/cluster-issuer"                   = var.cluster_issuer
-          "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-          "traefik.ingress.kubernetes.io/router.tls"         = "true"
-        }
-        hosts = [
-          {
-            host = local.domain
-            paths = [{
-              path     = "/"
-              pathType = "ImplementationSpecific"
-            }]
-          }
-        ]
-        # -- Ingress tls configuration for https access
-        tls = [{
-          secretName = "mlflow-ingres-tls"
-          hosts = [
-            local.domain
-          ]
-        }]
+        enabled : false
+      }
+      httproute = {
+        enabled           = true
+        host              = local.domain
+        gateway_name      = var.gateway_name
+        gateway_namespace = var.gateway_namespace
       }
     }
   }]

--- a/locals.tf
+++ b/locals.tf
@@ -46,12 +46,15 @@ locals {
         # -- Specifies if you want to create an ingress access
         enabled : false
       }
-      httproute = {
-        enabled           = true
-        host              = local.domain
-        gateway_name      = var.gateway_name
-        gateway_namespace = var.gateway_namespace
-      }
+    }
+  }]
+
+  helm_values_httproute = [{
+    httproute = {
+      enabled           = true
+      host              = local.domain
+      gateway_name      = var.gateway_name
+      gateway_namespace = var.gateway_namespace
     }
   }]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -55,6 +55,24 @@ locals {
       host              = local.domain
       gateway_name      = var.gateway_name
       gateway_namespace = var.gateway_namespace
+      # When oidc is configured, HTTPRoute points to oauth2-proxy instead of mlflow directly
+      backend_service = var.oidc != null ? "mlflow-oauth2-proxy" : "mlflow"
+      backend_port    = var.oidc != null ? 4180 : 80
     }
   }]
+
+  helm_values_oauth2proxy = var.oidc != null ? [{
+    oauth2proxy = {
+      enabled      = true
+      upstreamUrl  = "http://mlflow:80"
+      redirectUrl  = "https://${local.domain}/oauth2/callback"
+      cookieSecret = random_password.oauth2_proxy_cookie_secret.result
+      oidc = {
+        issuerUrl    = var.oidc.issuer_url
+        clientId     = var.oidc.client_id
+        clientSecret = var.oidc.client_secret
+      }
+      extraArgs = var.oidc.oauth2_proxy_extra_args
+    }
+  }] : []
 }

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "argocd_project" "this" {
 }
 
 data "utils_deep_merge_yaml" "values" {
-  input = [for i in concat(local.helm_values, var.helm_values) : yamlencode(i)]
+  input = [for i in concat(local.helm_values, local.helm_values_httproute, var.helm_values) : yamlencode(i)]
 }
 
 resource "argocd_application" "this" {

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,11 @@ resource "null_resource" "dependencies" {
   triggers = var.dependency_ids
 }
 
+resource "random_password" "oauth2_proxy_cookie_secret" {
+  length  = 32
+  special = false
+}
+
 resource "argocd_project" "this" {
   count = var.argocd_project == null ? 1 : 0
 
@@ -35,7 +40,7 @@ resource "argocd_project" "this" {
 }
 
 data "utils_deep_merge_yaml" "values" {
-  input = [for i in concat(local.helm_values, local.helm_values_httproute, var.helm_values) : yamlencode(i)]
+  input = [for i in concat(local.helm_values, local.helm_values_httproute, local.helm_values_oauth2proxy, var.helm_values) : yamlencode(i)]
 }
 
 resource "argocd_application" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,9 @@ variable "oidc" {
   })
   default = null
 }
+
+variable "allowed_groups" {
+  description = "List of Keycloak groups allowed to access MLflow (e.g. ["/data-scientists"]). When empty, any authenticated user is allowed. Only effective when oidc is configured."
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -116,3 +116,17 @@ variable "gateway_namespace" {
   type        = string
   default     = "istio-ingress"
 }
+
+variable "oidc" {
+  description = "OIDC configuration for oauth2-proxy authentication in front of MLflow. When set, all requests are authenticated via the configured OIDC provider (e.g. Keycloak) before reaching MLflow."
+  type = object({
+    issuer_url              = string
+    oauth_url               = string
+    token_url               = string
+    api_url                 = string
+    client_id               = string
+    client_secret           = string
+    oauth2_proxy_extra_args = optional(list(string), [])
+  })
+  default = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -104,3 +104,15 @@ variable "database" {
     service  = string
   })
 }
+
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach HTTPRoutes to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace where the Istio Gateway resource is deployed."
+  type        = string
+  default     = "istio-ingress"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -132,7 +132,7 @@ variable "oidc" {
 }
 
 variable "allowed_groups" {
-  description = "List of Keycloak groups allowed to access MLflow (e.g. ["/data-scientists"]). When empty, any authenticated user is allowed. Only effective when oidc is configured."
+  description = "List of Keycloak groups allowed to access MLflow (e.g. [\"/data-scientists\"]). When empty, any authenticated user is allowed. Only effective when oidc is configured."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Changes

- Migrate from Traefik Ingress to Istio Gateway API HTTPRoute
- Add `gateway_name` and `gateway_namespace` variables
- Add `allowed_groups` variable for RBAC via oauth2-proxy
- Add oauth2-proxy for Keycloak SSO authentication
- Add `--skip-jwt-bearer-tokens` for programmatic MLflow access
- Fix groups scope and quote escaping